### PR TITLE
차트 기능 추가 및 화면 레이아웃 수정 등

### DIFF
--- a/src/main/java/state/member/application/fasade/DashboardManager.java
+++ b/src/main/java/state/member/application/fasade/DashboardManager.java
@@ -21,11 +21,27 @@ public class DashboardManager {
         this.dashboardGetSystem1DataProcessor = dashboardGetSystem1DataProcessor;
         this.dashboardGetSystem2DataProcessor = dashboardGetSystem2DataProcessor;
     }
-    public Flux<TempRequestDto> getSystems1UsageData() {
-        return dashboardGetSystem1DataProcessor.execute();
+    public Flux<TempRequestDto> getSystems1AnnulData() {
+        return dashboardGetSystem1DataProcessor.annualExecute();
     }
 
-    public Flux<TempRequestDto> getSystems2UsageData() {
-        return dashboardGetSystem2DataProcessor.execute();
+    public Flux<TempRequestDto> getSystem1MonthlyData(String year) {
+        return dashboardGetSystem1DataProcessor.monthlyExecute(year);
+    }
+
+    public Flux<TempRequestDto> getSystem1WeeklyData(String year, String month) {
+        return dashboardGetSystem1DataProcessor.weeklyExecute(year, month);
+    }
+
+    public Flux<TempRequestDto> getSystems2AnnulData() {
+        return dashboardGetSystem2DataProcessor.annualExecute();
+    }
+
+    public Flux<TempRequestDto> getSystem2MonthlyData(String year) {
+        return dashboardGetSystem2DataProcessor.monthlyExecute(year);
+    }
+
+    public Flux<TempRequestDto> getSystem2WeeklyData(String year, String month) {
+        return dashboardGetSystem2DataProcessor.weeklyExecute(year, month);
     }
 }

--- a/src/main/java/state/member/application/processor/dashboard/system1/DashboardGetSystem1DataProcessor.java
+++ b/src/main/java/state/member/application/processor/dashboard/system1/DashboardGetSystem1DataProcessor.java
@@ -14,20 +14,17 @@ import static state.member.infrastructure.WebClientHandler.getWebClient;
 public class DashboardGetSystem1DataProcessor {
     @Value("${services.service_1.url}")
     String serviceUrl;
-
-    public Flux<TempRequestDto> execute() {
-        //TODO 특정 시스템 데이터 추출 과정에서 에러 발생했을 때 어떻게 처리할 지 생각하기
-        WebClient service_1_conn = getWebClient(serviceUrl);
-
-        Flux<TempRequestDto> data = null;
+    Flux<TempRequestDto> data;
+    public Flux<TempRequestDto> annualExecute() {
+        data = null;
         try {
-            data = service_1_conn
+            data = getWebClient(serviceUrl)
                     .get()
                     .uri("/getData")
                     .retrieve()
                     .bodyToFlux(TempRequestDto.class)
                     .onErrorResume(e -> { // 에러 발생 시 null 반환
-                        System.err.println("System 1 데이터 호출 실패: " + e.getMessage());
+                        System.err.println("System 1 getData 데이터 호출 실패: " + e.getMessage());
                         return Flux.empty(); // null 반환
                     });
         } catch(Exception e) {
@@ -37,16 +34,41 @@ public class DashboardGetSystem1DataProcessor {
         return data;
     }
 
+    public Flux<TempRequestDto> monthlyExecute(String year) {
+        data = null;
+        try {
+            data = getWebClient(serviceUrl)
+                    .get()
+                    .uri("/getMonthlyData?year="+year)
+                    .retrieve()
+                    .bodyToFlux(TempRequestDto.class)
+                    .onErrorResume(e -> { // 에러 발생 시 null 반환
+                        System.err.println("System 1 getMonthlyData 데이터 호출 실패: " + e.getMessage());
+                        return Flux.empty(); // null 반환
+                    });
+        } catch(Exception e) {
+            log.info("External API ERROR : " + e.getMessage());
+        }
 
-//    return service_1.post()
-//            .uri("/getData")
-//                .retrieve()
-//                .onStatus(status -> status.is4xxClientError(),
-//    response -> Mono.error(new RuntimeException("클라이언트 오류 발생")))
-//            .onStatus(status -> status.is5xxServerError(),
-//    response -> Mono.error(new RuntimeException("서버 오류 발생")))
-//            .bodyToMono(String.class)
-//                .doOnError(WebClientResponseException.class, ex -> {
-//        log.error("에러 발생: {}", ex.getMessage());
-//    });
+        return data;
+    }
+
+    public Flux<TempRequestDto> weeklyExecute(String year, String month) {
+        data = null;
+        try {
+            data = getWebClient(serviceUrl)
+                    .get()
+                    .uri("/getWeeklyData?year="+year+"&month="+month)
+                    .retrieve()
+                    .bodyToFlux(TempRequestDto.class)
+                    .onErrorResume(e -> { // 에러 발생 시 null 반환
+                        System.err.println("System 1 getWeeklyData 데이터 호출 실패: " + e.getMessage());
+                        return Flux.empty(); // null 반환
+                    });
+        } catch(Exception e) {
+            log.info("External API ERROR : " + e.getMessage());
+        }
+
+        return data;
+    }
 }

--- a/src/main/java/state/member/application/processor/dashboard/system2/DashboardGetSystem2DataProcessor.java
+++ b/src/main/java/state/member/application/processor/dashboard/system2/DashboardGetSystem2DataProcessor.java
@@ -15,18 +15,55 @@ public class DashboardGetSystem2DataProcessor {
     @Value("${services.service_2.url}")
     String serviceUrl;
 
-    public Flux<TempRequestDto> execute() {
-        WebClient service_2_conn = getWebClient(serviceUrl);
-
-        Flux<TempRequestDto> data = null;
+    Flux<TempRequestDto> data;
+    public Flux<TempRequestDto> annualExecute() {
+        data = null;
         try {
-            data = service_2_conn
+            data = getWebClient(serviceUrl)
                     .get()
                     .uri("/getData")
                     .retrieve()
                     .bodyToFlux(TempRequestDto.class)
                     .onErrorResume(e -> { // 에러 발생 시 null 반환
-                        System.err.println("System 2 데이터 호출 실패: " + e.getMessage());
+                        System.err.println("System 2 getData 데이터 호출 실패: " + e.getMessage());
+                        return Flux.empty(); // null 반환
+                    });
+        } catch(Exception e) {
+            log.info("External API ERROR : " + e.getMessage());
+        }
+
+        return data;
+    }
+
+    public Flux<TempRequestDto> monthlyExecute(String year) {
+        data = null;
+        try {
+            data = getWebClient(serviceUrl)
+                    .get()
+                    .uri("/getMonthlyData?year="+year)
+                    .retrieve()
+                    .bodyToFlux(TempRequestDto.class)
+                    .onErrorResume(e -> { // 에러 발생 시 null 반환
+                        System.err.println("System 2 getMonthlyData 데이터 호출 실패: " + e.getMessage());
+                        return Flux.empty(); // null 반환
+                    });
+        } catch(Exception e) {
+            log.info("External API ERROR : " + e.getMessage());
+        }
+
+        return data;
+    }
+
+    public Flux<TempRequestDto> weeklyExecute(String year, String month) {
+        data = null;
+        try {
+            data = getWebClient(serviceUrl)
+                    .get()
+                    .uri("/getWeeklyData?year="+year+"&month="+month)
+                    .retrieve()
+                    .bodyToFlux(TempRequestDto.class)
+                    .onErrorResume(e -> { // 에러 발생 시 null 반환
+                        System.err.println("System 2 getWeeklyData 데이터 호출 실패: " + e.getMessage());
                         return Flux.empty(); // null 반환
                     });
         } catch(Exception e) {

--- a/src/main/java/state/member/infrastructure/WebClientHandler.java
+++ b/src/main/java/state/member/infrastructure/WebClientHandler.java
@@ -5,8 +5,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class WebClientHandler {
     public static WebClient getWebClient(String baseUrl) {
         return WebClient.builder()
-                .baseUrl(baseUrl) // 기본 URL 설정
-                .defaultHeader("Accept", "application/json") // 기본 헤더 설정
-                .build();
+                    .baseUrl(baseUrl) // 기본 URL 설정
+                    .defaultHeader("Accept", "application/json") // 기본 헤더 설정
+                    .build();
+
     }
 }

--- a/src/main/java/state/member/presentation/apis/DashBoardApi.java
+++ b/src/main/java/state/member/presentation/apis/DashBoardApi.java
@@ -16,41 +16,8 @@ import java.util.List;
 @Slf4j
 @Controller
 public class DashBoardApi {
-    private final DashboardManager dashboardManager;
-
-    public DashBoardApi(DashboardManager dashboardManager) {
-        this.dashboardManager = dashboardManager;
-    }
-
     @GetMapping("/dashboard")
     public String dashboard() {
         return "dashboard";
-    }
-
-    @ResponseBody
-    @GetMapping("/getServicesData")
-    public Mono<List<List<TempRequestDto>>> getEachServiceData() {
-        List<Flux<TempRequestDto>> list = new ArrayList<>();
-        list.add(dashboardManager.getSystems1UsageData());
-        list.add(dashboardManager.getSystems2UsageData());
-
-        //TODO WebFlux, WebClient에 대해 함께 설명이 있었다면 좋았을 것 같음
-        // 납득시킬만한 내용이 있었으면 베스트
-        // WebFlux에 대해 설명할 수 있는 문서를 작성했으면 좋겠음
-        // 내부로 시스템 들여와야 함
-        // 년도별 데이터를 가져올 수 있도록 구조를 잡고 데이터 건수가 화면에 노출되도록 수정 -> 차트가 변경되어도 됨.
-        // 파이차트 백분율로 데이터가 넘어오지 않았을 때 어떻게 보여줄 건지
-
-        // 모든 Flux를 Mono로 변환
-        List<Mono<List<TempRequestDto>>> monoList = list.stream()
-                .map(flux -> flux.collectList().defaultIfEmpty(new ArrayList<>()))
-                .toList();
-
-        // 병렬 처리로 모든 Mono 완료
-        return Mono.zip(monoList, results ->
-                Arrays.stream(results)
-                        .map(result -> (List<TempRequestDto>) result)
-                        .toList()
-        );
     }
 }

--- a/src/main/java/state/member/presentation/apis/Service1Api.java
+++ b/src/main/java/state/member/presentation/apis/Service1Api.java
@@ -1,0 +1,101 @@
+package state.member.presentation.apis;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import state.member.application.fasade.DashboardManager;
+import state.member.presentation.request.TempRequestDto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Controller
+@RequestMapping("/service1")
+public class Service1Api {
+    private final DashboardManager dashboardManager;
+
+    public Service1Api(DashboardManager dashboardManager) {
+        this.dashboardManager = dashboardManager;
+    }
+
+    @GetMapping
+    public String service1() {
+        return "serviceChart";
+    }
+
+    /**
+     * 서비스의 년도별, 월별, 주별 데이터를 모두 가져온다
+     * @return
+     */
+    @ResponseBody
+    @GetMapping("/getServicesData")
+    public Mono<List<List<TempRequestDto>>> getEachServiceData(@RequestParam String year, @RequestParam String month) {
+        List<Flux<TempRequestDto>> list = new ArrayList<>();
+        list.add(dashboardManager.getSystems1AnnulData());
+        list.add(dashboardManager.getSystem1MonthlyData(year));
+        list.add(dashboardManager.getSystem1WeeklyData(year, month));
+
+        //TODO WebFlux, WebClient에 대해 함께 설명이 있었다면 좋았을 것 같음
+        // 납득시킬만한 내용이 있었으면 베스트
+        // WebFlux에 대해 설명할 수 있는 문서를 작성했으면 좋겠음
+        // 내부로 시스템 들여와야 함
+        // 년도별 데이터를 가져올 수 있도록 구조를 잡고 데이터 건수가 화면에 노출되도록 수정 -> 차트가 변경되어도 됨.
+        // 파이차트 백분율로 데이터가 넘어오지 않았을 때 어떻게 보여줄 건지
+
+        // 모든 Flux를 Mono로 변환
+        List<Mono<List<TempRequestDto>>> monoList = list.stream()
+                .map(flux -> flux.collectList().defaultIfEmpty(new ArrayList<>()))
+                .toList();
+
+        // 병렬 처리로 모든 Mono 완료
+        return Mono.zip(monoList, results ->
+                Arrays.stream(results)
+                        .map(result -> (List<TempRequestDto>) result)
+                        .toList()
+        );
+    }
+
+    @ResponseBody
+    @GetMapping("/getMonthlyData")
+    public Mono<List<List<TempRequestDto>>> getMonthlyData(@RequestParam String year, @RequestParam String month) {
+        List<Flux<TempRequestDto>> list = new ArrayList<>();
+        list.add(dashboardManager.getSystem1MonthlyData(year));
+        list.add(dashboardManager.getSystem1WeeklyData(year, month));
+
+        // 모든 Flux를 Mono로 변환
+        List<Mono<List<TempRequestDto>>> monoList = list.stream()
+                .map(flux -> flux.collectList().defaultIfEmpty(new ArrayList<>()))
+                .toList();
+
+        // 병렬 처리로 모든 Mono 완료
+        return Mono.zip(monoList, results ->
+                Arrays.stream(results)
+                        .map(result -> (List<TempRequestDto>) result)
+                        .toList()
+        );
+    }
+
+    @ResponseBody
+    @GetMapping("/getWeeklyData")
+    public Mono<List<List<TempRequestDto>>> getWeeklyData(@RequestParam String year, @RequestParam String month) {
+        List<Flux<TempRequestDto>> list = new ArrayList<>();
+        list.add(dashboardManager.getSystem1WeeklyData(year, month));
+
+        // 모든 Flux를 Mono로 변환
+        List<Mono<List<TempRequestDto>>> monoList = list.stream()
+                .map(flux -> flux.collectList().defaultIfEmpty(new ArrayList<>()))
+                .toList();
+
+        // 병렬 처리로 모든 Mono 완료
+        return Mono.zip(monoList, results ->
+                Arrays.stream(results)
+                        .map(result -> (List<TempRequestDto>) result)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/state/member/presentation/apis/Service2Api.java
+++ b/src/main/java/state/member/presentation/apis/Service2Api.java
@@ -1,0 +1,89 @@
+package state.member.presentation.apis;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import state.member.application.fasade.DashboardManager;
+import state.member.presentation.request.TempRequestDto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Controller
+@RequestMapping("/service2")
+public class Service2Api {
+    private final DashboardManager dashboardManager;
+
+    public Service2Api(DashboardManager dashboardManager) {
+        this.dashboardManager = dashboardManager;
+    }
+
+    /**
+     * 서비스의 년도별, 월별, 주별 데이터를 모두 가져온다
+     * @return
+     */
+    @ResponseBody
+    @GetMapping("/getServicesData")
+    public Mono<List<List<TempRequestDto>>> getEachServiceData(@RequestParam String year, @RequestParam String month) {
+        List<Flux<TempRequestDto>> list = new ArrayList<>();
+        list.add(dashboardManager.getSystems2AnnulData());
+        list.add(dashboardManager.getSystem2MonthlyData(year));
+        list.add(dashboardManager.getSystem2WeeklyData(year, month));
+
+        // 모든 Flux를 Mono로 변환
+        List<Mono<List<TempRequestDto>>> monoList = list.stream()
+                .map(flux -> flux.collectList().defaultIfEmpty(new ArrayList<>()))
+                .toList();
+
+        // 병렬 처리로 모든 Mono 완료
+        return Mono.zip(monoList, results ->
+                Arrays.stream(results)
+                        .map(result -> (List<TempRequestDto>) result)
+                        .toList()
+        );
+    }
+
+    @ResponseBody
+    @GetMapping("/getMonthlyData")
+    public Mono<List<List<TempRequestDto>>> getMonthlyData(@RequestParam String year, @RequestParam String month) {
+        List<Flux<TempRequestDto>> list = new ArrayList<>();
+        list.add(dashboardManager.getSystem2MonthlyData(year));
+        list.add(dashboardManager.getSystem2WeeklyData(year, month));
+
+        // 모든 Flux를 Mono로 변환
+        List<Mono<List<TempRequestDto>>> monoList = list.stream()
+                .map(flux -> flux.collectList().defaultIfEmpty(new ArrayList<>()))
+                .toList();
+
+        // 병렬 처리로 모든 Mono 완료
+        return Mono.zip(monoList, results ->
+                Arrays.stream(results)
+                        .map(result -> (List<TempRequestDto>) result)
+                        .toList()
+        );
+    }
+
+    @ResponseBody
+    @GetMapping("/getWeeklyData")
+    public Mono<List<List<TempRequestDto>>> getWeeklyData(@RequestParam String year, @RequestParam String month) {
+        List<Flux<TempRequestDto>> list = new ArrayList<>();
+        list.add(dashboardManager.getSystem2WeeklyData(year, month));
+
+        // 모든 Flux를 Mono로 변환
+        List<Mono<List<TempRequestDto>>> monoList = list.stream()
+                .map(flux -> flux.collectList().defaultIfEmpty(new ArrayList<>()))
+                .toList();
+
+        // 병렬 처리로 모든 Mono 완료
+        return Mono.zip(monoList, results ->
+                Arrays.stream(results)
+                        .map(result -> (List<TempRequestDto>) result)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/state/member/presentation/request/TempRequestDto.java
+++ b/src/main/java/state/member/presentation/request/TempRequestDto.java
@@ -9,5 +9,7 @@ import lombok.ToString;
 @Getter
 public class TempRequestDto {
     String year;
+    String month;
+    String week;
     double usage;
 }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -11,6 +11,7 @@
     <script type="text/javascript" src="/js/toastui-chart.min.js"></script>
     <script src="/js/jquery-3.7.1.min.js"></script>
     <!--<script src="/js/scrollreveal.js"></script>-->
+    <!--https://github.com/nhn/tui.chart/blob/main/docs/ko/chart-pie.md -> 모든 차트의 핸들링 가이드-->
 </head>
 <body>
 <div class="container-fluid bg-light vh-100">
@@ -20,74 +21,32 @@
     <!-- Sidebar + Content -->
     <div class="row">
         <!-- Sidebar -->
-        <div class="col-md-2 bg-primary text-white vh-100 p-3">
+        <div class="col-md-2 text-white vh-100 p-4" style="background-color: #06357a; height: 100%">
             <ul class="nav flex-column">
                 <li class="nav-item">
                     <a class="nav-link text-white" href="#">회원정보</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="/dashboard/admin/userList">사용자 목록</a>
+                    <a class="nav-link text-white" href="/dashboard/admin/memberList">사용자 목록</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="/dashboard/admin/memberRegister">사용자 등록</a>
+                    <a class="nav-link text-white" onclick="selectService1()">Service_1</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link text-white" onclick="selectService2()">Service_2</a>
                 </li>
             </ul>
         </div>
 
         <!-- Main Content -->
         <div class="col-md-10 p-4">
-            <h1>시스템별 현황 조회 시스템</h1>
-            <div class="row">
-                <!-- Cards -->
-                <div class="col-md-3">
-                    <div class="card shadow-sm">
-                        <div class="card-body">
-                            <div id="pieChart"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-3">
-                    <div class="card shadow-sm">
-                        <div class="card-body">
-                            <div id="pieChart2"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-3">
-                    <div class="card shadow-sm">
-                        <div class="card-body">
-                            <div id="donutChart"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-3">
-                    <div class="card shadow-sm">
-                        <div class="card-body">
-                            <div id="donutChart2"></div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <h1 id="systemNm" style="padding-left: 20px; font-size: 2rem;">Service_1</h1>
 
-            <!-- Charts Section -->
-            <div class="row mt-4">
-                <div class="col-md-6">
-                    <div class="card shadow-sm">
-                        <div class="card-body">
-                            <div id="areaChart"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-6">
-                    <div class="card shadow-sm">
-                        <div class="card-body">
-                            <div id="columnChart"></div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <!-- 차트 화면 포함 -->
+            <div id="contentDiv"></div>
         </div>
     </div>
+
     <footer class="text-center py-3 bg-light mt-4">
         <small>© 2024 창업진흥원. All rights reserved.</small>
     </footer>
@@ -97,31 +56,69 @@
 <!-- Bootstrap JS -->
 <script src="/js/bootstrap.bundle.min.js"></script>
 <script th:inline="javascript">
-    var service_1;
-    var service_2;
+    let annualData;
+    let monthlyData;
+    let weeklyData;
+
+    let annualChart;
+    let monthlyChart;
+    let weeklyChart;
 
     $(document).ready(function(){
-        getData();
+        $.ajax({
+            url: '/service1',
+            type: 'GET',
+            dataType: 'html',
+            success: function(data) {
+                $('#contentDiv').html(data);
+
+                //최초 렌더링 service명 세팅
+                $('#systemNm').html('service_1' + getIcon());
+
+                chartInit();
+            },
+            error: function(error) {
+                console.error('Error:', error);
+            }
+        });
     });
 
-    function getData() {
+    function chartInit(url) {
+        //최초 조회 시 현재 년도 가져오기
+        let year = new Date().getFullYear();
+        let month = new Date().getMonth() + 1;
+
+        if(!url) url = '/service1';
+
         $.ajax({
-            url: '/getServicesData', // API 엔드포인트
-            type: 'GET',           // HTTP 메서드
-            dataType: 'json',      // 응답 데이터 타입
-            success: function(data) { // 성공 시 실행
+            url: url + '/getServicesData?year='+ year + '&month=' + month,
+            type: 'GET',
+            dataType: 'json',
+            success: function(data) {
                 console.dir(data);
                 /**
-                 * 1. service_1, service_2 세팅
-                 * 2. 차트 생성 function 실행
+                 * 1. 년도별, 월별, 주별 데이터 세팅
+                 * 2. API 호출 상태 ICON 세팅
+                 * 3. 차트 생성 function 실행
                  */
-                service_1 = data[0];
-                service_2 = data[1];
+                annualData = data[0];
+                monthlyData = data[1];
+                weeklyData = data[2];
 
-                createChart();
+                //데이터가 존재하지 않을 시 API 호출 상태 ICON 업데이트
+                if(!validateData()) {
+                    $('#statusIcon').css('background-color', '#dc3545');
+                }
+
+                // 성공 여부를 H1 태그에 표현하기
+                createAnnualChart();
+                createMonthlyChart();
+                createWeeklyChart();
             },
             error: function(error) { // 에러 시 실행
                 console.error('Error:', error);
+                // 실패 여부를 H1 태그에 표현하기
+                $('#statusIcon').css('background-color', '#dc3545');
             }
         });
     }
@@ -134,7 +131,6 @@
             credentials: 'same-origin' // CSRF 보호 활성화 시 필요
         })
             .then(response => {
-                console.dir(response);
                 if (response.ok) {
                     return response;
                 } else {
@@ -142,7 +138,6 @@
                 }
             })
             .then(data => {
-                //console.log(data.message); // 로그아웃 성공 메시지
                 window.location.href = '/loginForm'; // 로그인 페이지로 리다이렉트
             })
             .catch(error => {
@@ -150,212 +145,10 @@
             });
     }
 
-    function createChart() {
-        //컬럼차트
+    function createAnnualChart() {
+        //annual 차트
         {
-            const el = document.getElementById('columnChart');
-            let data = {
-                categories: [],
-                series: [],
-            };
-
-            //series.data 세팅
-            let service_1_data = [];
-            let service_2_data = [];
-
-            // 카테고리 세팅 여부
-            let categoryYn = false;
-
-            // 각 서비스의 API 호출 성공 여부에 영향을 미치게 하지 않기 위함
-            if( service_1 != null && service_1.length > 0 ) {
-                categoryYn = true;
-
-                //categories 세팅
-                for( var i = 0 ; i < service_1.length ; i++ ) {
-                    /**
-                     * categories(예시로는 페이지 별 사용률에서 '페이지')가 서비스마다 동일하게 가져올 수 있다면
-                     * 하나의 차트에 여러 서비스를 보여줄 수 있음
-                     */
-                    data.categories.push(service_1[i].year);
-                    service_1_data.push(service_1[i].usage);
-                    //service_2_data.push(service_2[i].usage);
-                }
-
-                data.series.push({
-                    name : 'service_1',
-                    data : service_1_data
-                })
-            }
-
-            if( service_2 != null && service_2.length > 0 ) {
-
-                if(!categoryYn) {
-                    categoryYn = true;
-                    for( var i = 0 ; i < service_2.length ; i++ ) {
-                        data.categories.push(service_2[i].year);
-                        service_2_data.push(service_2[i].usage);
-                    }
-                } else {
-                    for( var i = 0 ; i < service_2.length ; i++ ) {
-                        service_2_data.push(service_2[i].usage);
-                    }
-                }
-
-                // TODO 위에 코드를 이런 식으로 중복된 내용을 제거하려 리팩토링 할 수 있음. 하지만 아직 이해가 안되기 때문에 주석
-                // if (!categoryYn) {
-                //     categoryYn = true;
-                //     data.categories.push(...service_2.map(item => item.page));
-                // }
-                //
-                // service_2_data.push(...service_2.map(item => item.usage));
-
-                data.series.push({
-                    name : 'service_2',
-                    data : service_2_data
-                })
-            }
-
-            const options = {
-                chart: { title: 'Monthly Revenue', width: 550, height: 350 },
-                series: {
-                    dataLabels: {
-                        visible: true,
-                    },
-                },
-            };
-
-            const columnChart = toastui.Chart.columnChart({ el, data, options });
-        }
-
-        //파이 차트 -> 데이터의 통계를 백분율로 세팅하여 차트에 대입해야 함
-        {
-            const el = document.getElementById('pieChart');
-            let data = {
-                categories: ['system_1'],
-                series: [],
-            };
-
-            if( service_1 != null && service_1.length > 0 ) {
-                for (var i = 0; i < service_1.length; i++) {
-                    data.series.push({
-                        name: service_1[i].year,
-                        data: service_1[i].usage //실제로는 백분율로 데이터가 입력되어야 할 것으로 보임
-                    });
-                }
-            }
-
-            const options = {
-                chart: { title: 'Service_1', width: 250, height: 200 },
-                legend: {visible: true, showCheckbox: false, width: 30}, // 차트 옆에 체크박스처럼 조회되는 차트 데이터
-                series: {
-                    //dataLabels -> 차트 데이터 표시 옵션. 폰트 사이즈 핸들링은 제공되지 않는 것으로 보인다
-                    // https://github.com/nhn/tui.chart/blob/main/docs/ko/chart-pie.md -> 모든 차트의 핸들링 가이드
-                    dataLabels: {
-                        visible: true
-                    },
-                },
-                theme: {
-                    series: {
-                        dataLabels: {
-                            fontSize: 9
-                        },
-                    }
-                }
-            };
-
-            const pieChart = toastui.Chart.pieChart({ el, data, options });
-        }
-
-        //파이 차트2 -> 데이터의 통계를 백분율로 세팅하여 차트에 대입해야 함
-        {
-            const el = document.getElementById('pieChart2');
-            let data = {
-                categories: ['Service_2'],
-                series: [],
-            };
-
-            if( service_2 != null && service_2.length > 0 ) {
-                for (var i = 0; i < service_2.length; i++) {
-                    data.series.push({
-                        name: service_2[i].year,
-                        data: service_2[i].usage //실제로는 백분율로 데이터가 입력되어야 할 것으로 보임
-                    });
-                }
-            }
-
-            const options = {
-                chart: { title: 'Service_2', width: 250, height: 200 },
-                legend: {showCheckbox: false, width: 30} // 차트 옆에 체크박스처럼 조회되는 차트 데이터
-            };
-
-            const pieChart2 = toastui.Chart.pieChart({ el, data, options });
-        }
-
-        //파이차트 도넛 -> 데이터의 통계를 백분율로 세팅하여 차트에 대입해야 함
-        {
-            const el = document.getElementById('donutChart');
-            let data = {
-                categories: ['Service_1_donut'],
-                series: [],
-            };
-
-            if( service_1 != null && service_1.length > 0 ) {
-                for (var i = 0; i < service_1.length; i++) {
-                    data.series.push({
-                        name: service_1[i].year,
-                        data: service_1[i].usage //실제로는 백분율로 데이터가 입력되어야 할 것으로 보임
-                    });
-                }
-            }
-
-            const options = {
-                chart: { title: 'Service_1_donut', width: 250, height: 200 },
-                series: {
-                    radiusRange: {
-                        inner: '40%',
-                        outer: '100%',
-                    },
-                },
-                legend: {showCheckbox: false, width: 30} // 차트 옆에 체크박스처럼 조회되는 차트 데이터
-            };
-
-            const donutChart = toastui.Chart.pieChart({ el, data, options });
-        }
-
-        //파이차트 도넛2 -> 데이터의 통계를 백분율로 세팅하여 차트에 대입해야 함
-        {
-            const el = document.getElementById('donutChart2');
-            let data = {
-                categories: ['Service_2_donut'],
-                series: [],
-            };
-
-            if( service_2 != null && service_2.length > 0 ) {
-                for (var i = 0; i < service_2.length; i++) {
-                    data.series.push({
-                        name: service_2[i].year,
-                        data: service_2[i].usage //실제로는 백분율로 데이터가 입력되어야 할 것으로 보임
-                    });
-                }
-            }
-
-            const options = {
-                chart: { title: 'Service_2_donut', width: 250, height: 200 },
-                series: {
-                    radiusRange: {
-                        inner: '40%',
-                        outer: '100%',
-                    },
-                },
-                legend: {showCheckbox: false, width: 30} // 차트 옆에 체크박스처럼 조회되는 차트 데이터
-            };
-
-            const donutChart2 = toastui.Chart.pieChart({ el, data, options });
-        }
-
-        //area 차트
-        {
-            const el = document.getElementById('areaChart');
+            const el = document.getElementById('annualChart');
             let data = {
                 // page -> 이 값들은 모두 동일할 필요가 있을 것 같음.(여러 시스템의 데이터를 하나의 차트에서 보여준다면)
                 categories: [],
@@ -363,69 +156,302 @@
             };
 
             //series.data 세팅
-            let service_1_data = [];
-            let service_2_data = [];
-
-            // 카테고리 세팅 여부
-            let categoryYn = false;
+            let annual_data = [];
 
             // 각 서비스의 API 호출 성공 여부에 영향을 미치게 하지 않기 위함
-            if( service_1 != null && service_1.length > 0 ) {
-                categoryYn = true;
-
+            if( annualData != null && annualData.length > 0 ) {
                 //categories 세팅
-                for( var i = 0 ; i < service_1.length ; i++ ) {
+                for( var i = 0 ; i < annualData.length ; i++ ) {
                     /**
                      * categories(예시로는 페이지 별 사용률에서 '페이지')가 서비스마다 동일하게 가져올 수 있다면
                      * 하나의 차트에 여러 서비스를 보여줄 수 있음
                      */
-                    data.categories.push(service_1[i].year);
-                    service_1_data.push(service_1[i].usage);
-                    //service_2_data.push(service_2[i].usage);
+                    data.categories.push(annualData[i].year);
+                    annual_data.push(annualData[i].usage);
                 }
 
                 data.series.push({
                     name : 'service_1',
-                    data : service_1_data
+                    data : annual_data
                 })
             }
 
-            if( service_2 != null && service_2.length > 0 ) {
-                if(!categoryYn) {
-                    categoryYn = true;
-                    for( var i = 0 ; i < service_2.length ; i++ ) {
-                        data.categories.push(service_2[i].year);
-                        service_2_data.push(service_2[i].usage);
-                    }
-                } else {
-                    for( var i = 0 ; i < service_2.length ; i++ ) {
-                        service_2_data.push(service_2[i].usage);
-                    }
-                }
-
-                // TODO 위에 코드를 이런 식으로 중복된 내용을 제거하려 리팩토링 할 수 있음. 하지만 아직 이해가 안되기 때문에 주석
-                // if (!categoryYn) {
-                //     categoryYn = true;
-                //     data.categories.push(...service_2.map(item => item.page));
-                // }
-                //
-                // service_2_data.push(...service_2.map(item => item.usage));
-
-                data.series.push({
-                    name : 'service_2',
-                    data : service_2_data
-                })
-            }
+            const theme = getTheme();
 
             const options = {
-                chart: {title: 'sevice_usage', width: 550, height: 350},
+                chart: {title: '연간 현황', height: 350},
+                legend: {visible: false},
                 xAxis: {pointOnColumn: false, title: {text: 'year'}},
                 yAxis: {title: 'usage'},
-                series: { showDot: true, dataLabels: { visible: true, offsetY: 10 } },
+                series: { showDot: true, dataLabels: { visible: true, offsetY: -10 }, selectable: true },
+                theme
             };
 
-            const areaChart = toastui.Chart.areaChart({el, data, options});
+            annualChart = toastui.Chart.areaChart({el, data, options});
+
+            //area 데이터 클릭 이벤트
+            annualChart.on('selectSeries', function(e) {
+                //하나의 서비스만 차트에 보여지기 때문에 0번째 index를 가져온다.
+                let year = e.area[0].data.category;
+                annualChartClick(year);
+            })
         }
+    }
+
+    function createMonthlyChart() {
+        // month 차트
+        {
+            const el = document.getElementById('monthChart');
+            let data = {
+                categories: [],
+                series: [],
+                year: []
+            };
+
+            //series.data 세팅
+            let monthly_data = [];
+
+            // 각 서비스의 API 호출 성공 여부에 영향을 미치게 하지 않기 위함
+            if( monthlyData != null && monthlyData.length > 0 ) {
+                //categories 세팅
+                for( var i = 0 ; i < monthlyData.length ; i++ ) {
+                    /**
+                     * categories(예시로는 페이지 별 사용률에서 '페이지')가 서비스마다 동일하게 가져올 수 있다면
+                     * 하나의 차트에 여러 서비스를 보여줄 수 있음
+                     */
+                    data.categories.push(monthlyData[i].month);
+                    monthly_data.push(monthlyData[i].usage);
+                    data.year.push(monthlyData[i].year);
+                }
+
+                data.series.push({
+                    name : 'service_1',
+                    data : monthly_data
+                })
+            }
+
+            const theme = getTheme();
+
+            let title = data.year[0] + '년 월간 현황';
+            const options = {
+                chart: { title: title, height: 300 },
+                legend: {visible: false},
+                series: {
+                    dataLabels: {
+                        visible: true,
+                    },
+                    selectable: true
+                },
+                theme
+            };
+
+            monthlyChart = toastui.Chart.columnChart({ el, data, options });
+
+            monthlyChart.on('selectSeries', function(e) {
+                //하나의 서비스만 차트에 보여지기 때문에 0번째 index를 가져온다.
+                let month = e.column[0].data.category;
+                let year = data.year[0];
+
+                monthlyChartClick(year, month);
+            })
+        }
+    }
+
+    function createWeeklyChart() {
+        // week 차트
+        {
+            const el = document.getElementById('weekChart');
+            let data = {
+                categories: [],
+                series: [],
+                year: [],
+                month: []
+            };
+
+            //series.data 세팅
+            let weekly_data = [];
+
+            // 각 서비스의 API 호출 성공 여부에 영향을 미치게 하지 않기 위함
+            if( weeklyData != null && weeklyData.length > 0 ) {
+                //categories 세팅
+                for( var i = 0 ; i < weeklyData.length ; i++ ) {
+                    /**
+                     * categories(예시로는 페이지 별 사용률에서 '페이지')가 서비스마다 동일하게 가져올 수 있다면
+                     * 하나의 차트에 여러 서비스를 보여줄 수 있음
+                     */
+                    data.categories.push(weeklyData[i].week);
+                    weekly_data.push(weeklyData[i].usage);
+                    data.year.push(weeklyData[i].year);
+                    data.month.push(weeklyData[i].month);
+                }
+
+                data.series.push({
+                    name : 'service_1',
+                    data : weekly_data
+                })
+            }
+
+            const theme = getTheme();
+
+            let title = data.year[0] + '년 ' + data.month[0] + '월 주별 현황';
+            const options = {
+                chart: { title: title, height: 350 },
+                legend: {visible: false},
+                series: {
+                    dataLabels: {
+                        visible: true,
+                    },
+                },
+                theme
+            };
+
+            weeklyChart = toastui.Chart.columnChart({ el, data, options });
+        }
+    }
+
+    function annualChartClick(year) {
+        if(!year) {
+            alert("선택한 년도 정보를 가져올 수 없습니다");
+            return;
+        }
+
+        //현재 월 세팅
+        let month = new Date().getMonth() + 1;
+
+        $.ajax({
+            url: '/service1/getMonthlyData?year='+ year + '&month='+month,
+            type: 'GET',
+            dataType: 'json',
+            success: function(data) {
+                console.dir(data);
+                /**
+                 * 1. 가져온 데이터 null 체크
+                 * 2. 차트 초기화
+                 * 3. 데이터 다시 세팅
+                 */
+                //월별 데이터, 주별 데이터
+                if(data == null || data.length !== 2) {
+                    alert("월별 데이터가 존재하지 않습니다.");
+                    return;
+                }
+
+                monthlyData = data[0];
+                weeklyData = data[1];
+
+                //데이터가 존재하지 않을 시 API 호출 상태 ICON 업데이트
+                if(!validateData()) {
+                    $('#statusIcon').css('background-color', '#dc3545');
+                }
+
+                // 차트 destroy
+                monthlyChart.destroy();
+                weeklyChart.destroy();
+
+                // 새로운 데이터로 재생성
+                createMonthlyChart();
+                createWeeklyChart()
+            },
+            error: function(error) { // 에러 시 실행
+                console.error('Error:', error);
+            }
+        });
+    }
+
+    function monthlyChartClick(year, month) {
+        if(!year) {
+            alert("선택한 년도 정보를 가져올 수 없습니다");
+            return;
+        }
+
+        if(!month) {
+            alert("선택한 월의 정보를 가져올 수 없습니다");
+            return;
+        }
+
+        $.ajax({
+            url: '/service1/getWeeklyData?year='+ year + '&month='+month,
+            type: 'GET',
+            dataType: 'json',
+            success: function(data) {
+                console.dir(data);
+                /**
+                 * 1. 가져온 데이터 null 체크
+                 * 2. 차트 초기화
+                 * 3. 데이터 다시 세팅
+                 */
+                //월별 데이터, 주별 데이터
+                if(data == null || data.length !== 1) {
+                    alert("주별 데이터가 존재하지 않습니다.");
+                    return;
+                }
+
+                weeklyData = data[0];
+
+                //데이터가 존재하지 않을 시 API 호출 상태 ICON 업데이트
+                if(!validateData()) {
+                    $('#statusIcon').css('background-color', '#dc3545');
+                }
+
+                // 차트 destroy
+                weeklyChart.destroy();
+
+                // 새로운 데이터로 재생성
+                createWeeklyChart()
+            },
+            error: function(error) { // 에러 시 실행
+                console.error('Error:', error);
+            }
+        });
+    }
+
+    function getTheme() {
+        return {
+            series: {
+                dataLabels: {
+                    fontFamily: 'Arial',
+                    fontSize: 10,
+                    fontWeight: 400,
+                    color: '#110829',
+                    textBubble: {visible: true, arrow: {visible: true}},
+                },
+            },
+        };
+    }
+
+    function selectService1() {
+        destroyChart();
+
+        $('#systemNm').html('service_1' + getIcon());
+
+        chartInit('/service1');
+    }
+
+    function selectService2() {
+        destroyChart();
+
+        $('#systemNm').html('service_2' + getIcon());
+
+        chartInit('/service2');
+    }
+
+    function destroyChart() {
+        if(annualChart && monthlyChart && weeklyChart) {
+            annualChart.destroy();
+            monthlyChart.destroy();
+            weeklyChart.destroy();
+        }
+    }
+
+    function getIcon() {
+        return '<span id="statusIcon" style="display: inline-block; width: 15px; height: 15px; border-radius: 50%; background-color: #28a745; margin-left: 10px;"></span>';
+    }
+
+    function validateData() {
+        if(!annualData || annualData.length <= 0) return false;
+        if(!monthlyData || monthlyData.length <= 0) return false;
+        if(!weeklyData || weeklyData.length <= 0) return false;
+
+        return true;
     }
 
     ScrollReveal().reveal('.card', {

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -5,8 +5,12 @@
                 <img alt="창업진흥원" src="/img/mainLogo.png">
             </a>
             <div class="d-flex align-items-center ms-auto">
-                <a class="nav-link me-3 text-primary fw-bold" href="/member/member-profile">회원정보</a>
-                <button class="btn btn-primary" onclick="logout()">로그아웃</button>
+                <a class="nav-link me-3 text-primary fw-bold" href="/member/member-profile" style="
+                    margin-right: 0 !important;
+                    padding-right: 0 !important;
+                    color: #434343 !important;
+                ">회원정보</a>
+                <button class="btn btn-primary" onclick="logout()" style="background-color: #4d4d4d; border-color: #4d4d4d;">로그아웃</button>
             </div>
         </div>
     </nav>

--- a/src/main/resources/templates/serviceChart.html
+++ b/src/main/resources/templates/serviceChart.html
@@ -1,0 +1,30 @@
+<div class="container-fluid p-4">
+    <div class="row">
+        <!-- Cards -->
+        <div class="col-md-12">
+            <div class="card shadow-sm">
+                <div class="card-body" style="width: 100%">
+                    <div id="monthChart"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Charts Section -->
+    <div class="row mt-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <div id="annualChart" style="width: 100%"></div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <div id="weekChart" style="width: 100%"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
1. 대시보드 화면 css 수정
3. 차트 레이아웃 수정
4. API 호출 년도별, 월별, 주별 데이터를 가져올 수 있도록 수정
5. 대시보드 차트 기능 추가
   - 년도별 차트 데이터 클릭 시 선택한 년도의 `월별`, `주별` 차트 세팅
   - 월별 차트 데이터 클릭 시 선택한 월의 `주별` 차트 세팅